### PR TITLE
Flip logic from dpkg output

### DIFF
--- a/files/PVENagRemover.sh
+++ b/files/PVENagRemover.sh
@@ -2,6 +2,6 @@
 
 dpkg -V proxmox-widget-toolkit | grep -q 'proxmoxlib.js'
 
-if [ $? -eq 1 ]; then
+if [ $? -eq 0 ]; then
   sed -i '/data.status/{s/\!//;s/Active/NoMoreNagging/}' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
 fi


### PR DESCRIPTION
Hi there!  I was having some issues with the nag window persisting after running your role (with the correct variable set), and the fix on my end was modifying this script to look for an exit status of 0 instead of 1.

The dpkg command looks for proxmoxlib.js, and then if that's successful, the sed command should run.  With '$? -eq 1', it would only run if the file was not found, which seems like it would be counterproductive.

Am I missing something here by chance?